### PR TITLE
Fix link to Examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
             <ul class="nav navbar-nav navbar-nav-center">
                 <li><a href="https://github.com/appium/appium" data-localize="jumbotron-github">View on GitHub</a></li>
                 <li><a href="/downloads.html" data-localize="jumbotron-downloads">Downloads</a></li>
-                <li><a href="https://github.com/appium/appium/tree/master/sample-code/examples" data-localize="jumbotron-examples">Examples</a></li>
+                <li><a href="https://github.com/appium/sample-code/tree/master/sample-code/examples" data-localize="jumbotron-examples">Examples</a></li>
                 <li><a href="/slate/en/master/#credits.md" data-localize="jumbotron-contributions">Contributions</a></li>
                 <li><a href="https://travis-ci.org/appium/appium"><img
                         src="https://api.travis-ci.org/appium/appium.png?branch=master"


### PR DESCRIPTION
Looks like you guys moved some Github assets around. Updated the hyperlink on the homepage.
