### PR TITLE
Move chat to gitter

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -1,44 +1,14 @@
----
----
 <!DOCTYPE html>
 <html>
-{% include head.html %}
-<body>
-
-
-{% include navbar.html %}
-
-<div class="jumbotron masthead">
-    <div class="container">
-        <h1 class="img-responsive appium-logo">Appium</h1>
-        <img class="img-responsive code-bg" src="img/code-bg.gif"/>
-
-	<p data-localize="jumbotron-heading">Automation for Apps</p>
-
-        <p class="small"><span data-localize="jumbotron-p-pt1">Appium is an open source test automation framework for
-            use with native and</span> <a
-                    href="/slate/en/master/#hybrid.md"><span data-localize="jumbotron-p-pt2">hybrid</span></a><span data-localize="jumbotron-p-pt3"> mobile apps.</span> <br /><span data-localize="jumbotron-p-pt4">It drives iOS and Android apps using the WebDriver</span>
-            <a href="http://code.google.com/p/selenium/wiki/JsonWireProtocol"><span data-localize="jumbotron-p-pt5">JSON
-                wire protocol</span></a><span data-localize="jumbotron-p-pt6">.</span></p>
-        <p>
-            <a href="https://www.hipchat.com/gTJJXSZBF"
-               class="btn btn-primary btn-lg" 
-               role="button"
-               style="color: white;">Appium HipChat (Guest - no account required)</a>
-            <a href="https://appium.hipchat.com/chat"
-               class="btn btn-primary btn-lg" 
-               role="button"
-               style="color: white;">Appium HipChat (Member)</a>
-            <a href="https://www.hipchat.com/invite/107647/7a3bbdd0bb2a8a07f98df7fbe3db8206"
-               class="btn btn-primary btn-lg"
-               role="button"
-               style="color: white;">Create HipChat Account (enables chat history)</a>
-        </p>
-    </div>
-</div>
-
-{% include footer.html %}
+<head>
+<meta http-equiv="refresh" content="0;url=http://gitter.im/appium/appium">
 <script>
+window.location.replace("http://gitter.im/appium/appium");
 </script>
+</head>
+
+<body>
+<a href="http://gitter.im/appium/appium">http://gitter.im/appium/appium</a>
 </body>
+
 </html>


### PR DESCRIPTION
@0x1mason suggested gitter which is way better than hipchat for public discussion. This PR replaces the [appium.io/chat](http://appium.io/chat) with a redirect to [our gitter channel](https://gitter.im/appium/appium). Note this doesn't replace Slack.
