### PR TITLE
Fix broken brew link

### DIFF
--- a/slate/en/tutorial/android.html
+++ b/slate/en/tutorial/android.html
@@ -205,7 +205,7 @@ gem install --no-rdoc --no-ri flaky
 </li>
 </ul>
 
-<p><code class="prettyprint">ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"</code></p>
+<p><code class="prettyprint">ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"</code></p>
 
 <ul>
 <li>Install <a href="http://nodejs.org/">nodejs</a> using brew.</li>


### PR DESCRIPTION
Fixed: Broken brew link pointing to a Github 404. Replaced with the given URL on http://brew.sh/.

When following the tutorial for getting Appium started for Native Android at: http://appium.io/slate/en/tutorial/android.html,
I encountered this errror.
ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
curl: (22) The requested URL returned error: 404 Not Found
So, replaced the 404 URL with the given url on the actual brew site, to keep it up to date.
