### PR TITLE
Remap .md links to .html

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jsdom": "^5.0.0",
     "lodash": "^4.17.4",
     "octonode": "^0.8.0",
+    "replace-ext": "^1.0.0",
     "request-promise": "^4.2.1",
     "teen_process": "^1.10.0",
     "unzip": "^0.1.11"
@@ -52,6 +53,7 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-promise": "^3.5.0",
+    "is-absolute-url": "^2.1.0",
     "rimraf": "^2.6.1"
   }
 }

--- a/scripts/links.js
+++ b/scripts/links.js
@@ -1,0 +1,41 @@
+import jQuery from 'jquery';
+import { jsdom } from 'jsdom';
+import path from 'path';
+import replaceExtension from 'replace-ext';
+import isAbsoluteUrl from 'is-absolute-url';
+
+const $ = jQuery(jsdom().defaultView);
+
+/**
+ * Markdown doesn't render absolute links to markdown files (see https://github.com/mkdocs/mkdocs/issues/1172)
+ * 
+ * @param {String} html 
+ */
+export function reassignMarkdownLink (html) {
+  const jqHTML = $(html);
+  const anchorTags = jqHTML.find('a');
+  anchorTags.each((index, tag) => {
+    const anchorTag = $(tag);
+    const href = anchorTag.attr('href');
+
+    if (href && !isAbsoluteUrl(href)) {
+      const ext = path.extname(href);
+      if (ext === '.md') {
+        anchorTag.attr('href', `${replaceExtension(href, '')}/index.html`);
+      }
+    }
+  });
+  return jqHTML.html();
+}
+
+/**
+ * Takes a document, parses out the body and then adds fenced code to the body
+ * @param {*} htmlDocString 
+ */
+export function reassignMarkdownLinkDocument (htmlDocString) {
+  const body = '<div id="body-mock">' + htmlDocString.replace(/^[\s\S]*<body.*?>|<\/body>[\s\S]*$/ig, '') + '</div>';
+  const newBody = reassignMarkdownLink(body);
+  const bodyStart = htmlDocString.indexOf('<body>') + '<body>'.length;
+  const bodyEnd = htmlDocString.indexOf('</body>');
+  return htmlDocString.substr(0, bodyStart) + newBody + htmlDocString.substr(bodyEnd, htmlDocString.length - bodyEnd);
+}

--- a/scripts/links.js
+++ b/scripts/links.js
@@ -29,7 +29,7 @@ export function reassignMarkdownLink (html) {
 }
 
 /**
- * Takes a document, parses out the body and then adds fenced code to the body
+ * Takes a document, parses out the body and then remaps anchor tags to point to HTML links
  * @param {*} htmlDocString 
  */
 export function reassignMarkdownLinkDocument (htmlDocString) {

--- a/scripts/repo.js
+++ b/scripts/repo.js
@@ -9,6 +9,7 @@ import B from 'bluebird';
 import Handlebars from 'handlebars';
 import _ from 'lodash';
 import { fencedCodeTabifyDocument } from './tabs';
+import { reassignMarkdownLinkDocument } from './links';
 
 const LANGUAGES = ['en', 'cn'];
 const SITEMAP = {
@@ -139,12 +140,14 @@ async function alterDocs (pathToDocs) {
   }
 }
 
-async function applyTabs (pathToHTML) {
+async function alterHTML (pathToHTML) {
   for (const file of await fs.glob(path.resolve(pathToHTML, '**/*.html'))) {
     const stat = await fs.stat(path.resolve(pathToHTML, file));
     if (!stat.isDirectory()) {
       const filePath = path.resolve(pathToHTML, file);
-      let treatedHTML = fencedCodeTabifyDocument(await fs.readFile(filePath, 'utf8'));
+      let treatedHTML = await fs.readFile(filePath, 'utf8');
+      treatedHTML = fencedCodeTabifyDocument(treatedHTML);
+      treatedHTML = reassignMarkdownLinkDocument(treatedHTML);
       await fs.writeFile(filePath, treatedHTML);
     }
   }
@@ -177,7 +180,7 @@ async function buildDocs (pathToDocs) {
     await exec('mkdocs', ['build', '--site-dir', pathToBuildDocsTo], {
       cwd: pathToDocs,
     });
-    await applyTabs(pathToBuildDocsTo);
+    await alterHTML(pathToBuildDocsTo);
   }
 }
 

--- a/test/links-specs.js
+++ b/test/links-specs.js
@@ -8,14 +8,17 @@ chai.should();
 describe('links.js', function () {
   describe('.reassignMarkdownLink', function () {
     it('should change extension of absolute paths from .md to html', function () {
-      reassignMarkdownLink(`<div><a href="/docs/en/path/to/hello-world.md"></a></div>`).should.equal(`<a href="/docs/en/path/to/hello-world/index.html"></a>`);
+      reassignMarkdownLink(`<div><a href="/docs/en/path/to/hello-world.md"></a></div>`)
+        .should.equal(`<a href="/docs/en/path/to/hello-world/index.html"></a>`);
     });
     it('should ignore absolute URL paths', function () {
       const markup = `<div><a href="http://example.com/docs/en/path/to/hello-world.md"></a></div>`;
-      reassignMarkdownLink(markup).should.equal(`<a href="http://example.com/docs/en/path/to/hello-world.md"></a>`);
+      reassignMarkdownLink(markup)
+        .should.equal(`<a href="http://example.com/docs/en/path/to/hello-world.md"></a>`);
     });
     it('should change extensions of relative paths', function () {
-      reassignMarkdownLink(`<div><div><a href="docs/en/path/to/hello-world.md"></a></div></div>`).should.equal(`<div><a href="docs/en/path/to/hello-world/index.html"></a></div>`);
+      reassignMarkdownLink(`<div><div><a href="docs/en/path/to/hello-world.md"></a></div></div>`)
+        .should.equal(`<div><a href="docs/en/path/to/hello-world/index.html"></a></div>`);
     });
     it('should change extensions of multiple absolute paths from .md to html', function () {
       reassignMarkdownLink(`<div><div><a href="/docs/en/path/to/hello-world.md"><a href="foo-bar.md"></a></div></div>`)

--- a/test/links-specs.js
+++ b/test/links-specs.js
@@ -1,0 +1,25 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { reassignMarkdownLink } from '../scripts/links';
+
+chai.use(chaiAsPromised);
+chai.should();
+
+describe('links.js', function () {
+  describe('.reassignMarkdownLink', function () {
+    it('should change extension of absolute paths from .md to html', function () {
+      reassignMarkdownLink(`<div><a href="/docs/en/path/to/hello-world.md"></a></div>`).should.equal(`<a href="/docs/en/path/to/hello-world/index.html"></a>`);
+    });
+    it('should ignore absolute URL paths', function () {
+      const markup = `<div><a href="http://example.com/docs/en/path/to/hello-world.md"></a></div>`;
+      reassignMarkdownLink(markup).should.equal(`<a href="http://example.com/docs/en/path/to/hello-world.md"></a>`);
+    });
+    it('should change extensions of relative paths', function () {
+      reassignMarkdownLink(`<div><div><a href="docs/en/path/to/hello-world.md"></a></div></div>`).should.equal(`<div><a href="docs/en/path/to/hello-world/index.html"></a></div>`);
+    });
+    it('should change extensions of multiple absolute paths from .md to html', function () {
+      reassignMarkdownLink(`<div><div><a href="/docs/en/path/to/hello-world.md"><a href="foo-bar.md"></a></div></div>`)
+        .should.equal(`<div><a href="/docs/en/path/to/hello-world/index.html"></a><a href="foo-bar/index.html"></a></div>`);
+    });
+  });
+});


### PR DESCRIPTION
* E.g.: `docs/en/appium-setup/platform-support.md` remaps to `docs/en/appium-setup/platform-support/index.html`
* Absolute URL's are untouched