### PR TITLE
Sort tabs by language priority

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "chai-as-promised": "^7.1.1",
     "fs-promise": "^2.0.3",
     "github": "^9.2.0",
-    "handlebars": "^4.0.10",
     "jquery": "^3.2.1",
     "jsdom": "^5.0.0",
     "lodash": "^4.17.4",
@@ -47,12 +46,14 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "ejs": "^2.5.7",
     "eslint": "^4.5.0",
     "eslint-config-appium": "^2.0.1",
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-promise": "^3.5.0",
+    "handlebars": "^4.0.10",
     "is-absolute-url": "^2.1.0",
     "rimraf": "^2.6.1"
   }

--- a/scripts/tabs.js
+++ b/scripts/tabs.js
@@ -1,5 +1,6 @@
 import jQuery from 'jquery';
 import { jsdom } from 'jsdom';
+import ejs from 'ejs';
 
 const $ = jQuery(jsdom().defaultView);
 
@@ -12,6 +13,8 @@ const LANGUAGE_DISPLAY_NAMES = {
   'objectivec': 'Objective-C',
   'csharp': 'C#',
 };
+
+const LANGUAGE_ORDER = ['java', 'python', 'javascript', 'ruby', 'csharp', 'php'];
 
 function capitalize (languageName) {
   if (!languageName) {
@@ -26,45 +29,65 @@ function capitalize (languageName) {
   return languageName.charAt(0).toUpperCase() + languageName.slice(1);
 }
 
-function appendLanguageBlock (tabEl, preEl, languageName, id, active) {
-  const navTag = tabEl.find('.nav');
-  navTag.append(`<li role="presentation" ${active ? 'class="active"' : ''} role="tab">
-    <a href='#${id}' data-toggle='tab'>${capitalize(languageName)}</a>
-  </li>`);
-  const tabPanel = tabEl.find('.tab-content');
-  let html = preEl[0].outerHTML;
-  html = stripLanguageComment(html);
-  tabPanel.append(`<div role="tabpanel" class="tab-pane ${active ? 'active' : ''}" id="${id}">${html.trim()}</div>`);
-}
-
 export function fencedCodeTabify (html) {
   const jqHTML = $(html);
-  let tabTagHTML = `<div>
-    <ul class="nav nav-tabs" role="tablist">
-    </ul>
-    <div class="tab-content">
-    </div>
-  </div>`;
 
   let tabPaneIndex = 0;
+
+  let languageBlocks = [];
 
   jqHTML.find("pre > code").each((index, codeTag) => {
     const preTag = $(codeTag).parent();
     const siblings = preTag.nextAll();
-    const tabEl = $(tabTagHTML);
     let language = capitalize($(codeTag).attr('class'));
-    let siblingIndex = 0;
-    appendLanguageBlock(tabEl, preTag, language, `${tabPaneIndex}_${siblingIndex++}`, true);
+
+    let siblingCount = 1;
+    languageBlocks.push({
+      language: language.toLowerCase(),
+      capitalizedLanguage: capitalize(language),
+      html: stripLanguageComment(preTag[0].outerHTML),
+      tabPaneIndex,
+    });
     siblings.each(function (index, siblingEl) {
       language = $(siblingEl).find('code').attr('class');
       if (!language) {
         return false;
       }
-      appendLanguageBlock(tabEl, $(siblingEl), language, `${tabPaneIndex}_${siblingIndex++}`);
+      siblingCount++;
+      languageBlocks.push({
+        language: language.toLowerCase(),
+        capitalizedLanguage: capitalize(language),
+        html: stripLanguageComment($(siblingEl)[0].outerHTML),
+        tabPaneIndex,
+      });
       $(siblingEl).remove();
     });
-    if (siblingIndex > 1) {
-      preTag.replaceWith(tabEl);
+    if (siblingCount > 1) {
+      const tabTemplate = `<div>
+        <ul class="nav nav-tabs" role="tablist">
+          <% for (var i=0; i<languages.length; i++) { %>
+          <li role="presentation" class="<%= i === 0 ? 'active' : '' %>">
+              <a href="#<%= languages[i].tabPaneIndex + '_' + i %>" data-toggle="tab"><%= languages[i].capitalizedLanguage %></a>
+          </li>
+          <% } %>
+        </ul>
+        <div class="tab-content">
+          <% for (var i=0; i<languages.length; i++) { %>
+          <div role="tabpanel" class="tab-pane <%= i === 0 ? 'active' : '' %>" id="<%= languages[i].tabPaneIndex + '_' + i %>">
+            <%- languages[i].html %>
+          </div>
+          <% } %>
+        </div>
+      </div>`;
+      languageBlocks.sort((blockOne, blockTwo) => {
+        if (LANGUAGE_ORDER.indexOf(blockTwo.language) === undefined || LANGUAGE_ORDER.indexOf(blockOne.language) > LANGUAGE_ORDER.indexOf(blockTwo.language)) {
+          return 1;
+        } else {
+          return -1;
+        }
+      });
+      preTag.replaceWith($(ejs.render(tabTemplate, {languages: languageBlocks})));
+      languageBlocks = [];
       tabPaneIndex++;
     }
   });

--- a/test/tabs-specs.js
+++ b/test/tabs-specs.js
@@ -112,6 +112,22 @@ describe('Repo.js', function () {
       </div>`).indexOf('// Javascript').should.be.below(0);
     });
 
+    it('should order the language comments by priority', function () {
+
+      const html = fencedCodeTabify(`<div>
+        <pre>
+          <code class='python'>// Python 
+          JS code</code>
+        </pre>
+        <pre>
+          <code class='java'>// Java 
+          JS code</code>
+        </pre>
+      </div>`);
+
+      html.indexOf('java').should.be.below(html.indexOf('python'));
+    });
+
     it('should parse an HTML file', async function () {
       fencedCodeTabifyDocument(await fs.readFile(path.resolve(__dirname, 'fixtures', 'sample.html'), 'utf8')).indexOf('nav-tabs').should.be.above(0);
     });


### PR DESCRIPTION
* Use EJS template to render the tabs instead of raw jQuery (the jQuery code was getting out of hand and difficult to edit)
* Sort the language tabs by priority (Java comes first, then Python, Javascript, etc...)