### PR TITLE
Fix toggling of dropdown menus for mobile

### DIFF
--- a/cinder/css/base.css
+++ b/cinder/css/base.css
@@ -133,10 +133,6 @@ div.source-links {
     border-radius: 0 6px 6px 6px;
 }
 
-.dropdown-submenu:hover>.dropdown-menu {
-    display: block;
-}
-
 .dropdown-submenu>a:after {
     display: block;
     content: " ";
@@ -161,7 +157,7 @@ div.source-links {
 
 .dropdown-submenu.pull-left>.dropdown-menu {
     left: -100%;
-    margin-left: 00px;
+    margin-left: 10px;
     -webkit-border-radius: 6px 0 6px 6px;
     -moz-border-radius: 6px 0 6px 6px;
     border-radius: 6px 0 6px 6px;

--- a/cinder/js/base.js
+++ b/cinder/js/base.js
@@ -16,5 +16,12 @@ $("li.disabled a").click(function() {
     event.preventDefault();
 });
 
-
-
+/* handle menu/submenu toggling */
+$('ul.dropdown-menu [data-toggle=dropdown]').on('click', function(event) {
+  // Avoid following the href location when clicking
+  event.preventDefault();
+  // Avoid having the menu to close when clicking
+  event.stopPropagation();
+  // toggle the closest dropdown
+  $(this).closest(".dropdown-submenu").toggleClass("open");
+});

--- a/cinder/nav-sub.html
+++ b/cinder/nav-sub.html
@@ -3,8 +3,8 @@
     <a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
 </li>
 {% else %}
-  <li class="dropdown-submenu">
-    <a tabindex="-1" href="">{{ nav_item.title }}</a>
+  <li class="menu-item dropdown-submenu">
+    <a class="dropdown-toggle" data-toggle="dropdown" href="">{{ nav_item.title }}</a>
     <ul class="dropdown-menu">
         {% for nav_item in nav_item.children %}
             {% include "nav-sub.html" %}

--- a/cinder/nav.html
+++ b/cinder/nav.html
@@ -20,14 +20,14 @@
         </div>
 
         <!-- Expanded navigation -->
-        <div class="navbar-collapse collapse">
+        <div class="collapse navbar-collapse navbar-ex1-collapse">
             {% if include_nav %}
                 <!-- Main navigation -->
                 <ul class="nav navbar-nav">
                 {% for nav_item in nav %}
                 {% if nav_item.title != 'Home' %}
                 {% if nav_item.children %}
-                    <li class="dropdown{% if nav_item.active %} active{% endif %}">
+                    <li class="menu-item dropdown{% if nav_item.active %} active{% endif %}">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>
                         <ul class="dropdown-menu">
                         {% for nav_item in nav_item.children %}


### PR DESCRIPTION
Dropdown/sub-dropdowntoggling is broken on mobile (see #107). This JS hack fixes it, while keeping the desktop functionality.

<img width="1019" alt="screenshot 2017-12-11 08 37 18" src="https://user-images.githubusercontent.com/2614354/33833808-e1c23bdc-de4e-11e7-85a2-5fb1bfbe97b0.png">
<img width="1093" alt="screenshot 2017-12-11 08 37 07" src="https://user-images.githubusercontent.com/2614354/33833812-e37b7614-de4e-11e7-9759-c1b3d0be5b16.png">
