### PR TITLE
Corrected safariInitialUrl compatibility

### DIFF
--- a/docs/en/writing-running-appium/caps/index.html
+++ b/docs/en/writing-running-appium/caps/index.html
@@ -1909,7 +1909,7 @@ Driver</a>.</p>
 </tr>
 <tr>
 <td><code>safariInitialUrl</code></td>
-<td>(Sim-only) (&gt;= 8.1) Initial safari url, default is a local welcome page</td>
+<td>(&gt;= 8.1) Initial safari url, default is http://www.appium.io</td>
 <td>e.g. <code>https://www.github.com</code></td>
 </tr>
 <tr>


### PR DESCRIPTION
With XCUItest, safariInitialUrl capability is used on a real device (as tested on 1.7.1).

See https://github.com/appium/appium-xcuitest-driver/blob/a6210175df82721406523aaca5ee986210757c82/lib/driver.js