### PR TITLE
Instruct pin MkDocs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ To locally preview appium.io
 ## Requirements
 
 1. [Ruby 2.1.0 or higher](https://www.ruby-lang.org/en/downloads/)
-2. Node + NPM
-3. Ruby Bundler (`gem install bundler`)
-4. MkDocs (`brew install mkdocs`)
+1. Node + NPM
+1. Ruby Bundler (`gem install bundler`)
+1. pip (`brew install pip`)
+1. MkDocs 0.16.3 (`pip install mkdocs==0.16.3`)
 
 ## Setup
 


### PR DESCRIPTION
* MkDocs 0.17 was breaking
* Update instructions to tell users to pin version to 0.16.3
* Instruct to use `pip` installation instead of `brew` because brew installation of specific versions isn't obvious