### PR TITLE
Updating the docs to reflect that Python client supports get_settings and update_settings functionality

### DIFF
--- a/docs/en/commands/session/settings/get-settings/index.html
+++ b/docs/en/commands/session/settings/get-settings/index.html
@@ -1554,7 +1554,7 @@
           </div>
           
           <div role="tabpanel" class="tab-pane " id="0_1">
-            <pre><code class="python"># Not supported
+            <pre><code class="python">settings = driver.get_settings()
 </code></pre>
           </div>
           
@@ -1673,8 +1673,8 @@ await driver.settings();
 </tr>
 <tr>
 <td><a href="https://github.com/appium/python-client/releases/latest">Python</a></td>
-<td>None</td>
-<td></td>
+<td>All</td>
+<td><a href="https://github.com/appium/python-client/blob/master/README.md#appium-settings">github.com</a></td>
 </tr>
 <tr>
 <td><a href="http://webdriver.io/index.html">Javascript (WebdriverIO)</a></td>

--- a/docs/en/commands/session/settings/update-settings/index.html
+++ b/docs/en/commands/session/settings/update-settings/index.html
@@ -1554,7 +1554,7 @@
           </div>
           
           <div role="tabpanel" class="tab-pane " id="0_1">
-            <pre><code class="python"># Not supported
+            <pre><code class="python">driver.update_settings({"some setting": "the value"})
 </code></pre>
           </div>
           
@@ -1673,8 +1673,8 @@ await driver.updateSettings({nativeWebTap: true});
 </tr>
 <tr>
 <td><a href="https://github.com/appium/python-client/releases/latest">Python</a></td>
-<td>None</td>
-<td></td>
+<td>All</td>
+<td><a href="https://github.com/appium/python-client/blob/master/README.md#appium-settings">github.com</a></td>
 </tr>
 <tr>
 <td><a href="http://webdriver.io/index.html">Javascript (WebdriverIO)</a></td>


### PR DESCRIPTION
Hi, 
Just a minor change to the docs. I've noticed that appium.io lists these methods
https://appium.io/docs/en/commands/session/settings/update-settings/
https://appium.io/docs/en/commands/session/settings/get-settings/
 as not supported by Python client. However they are implemented since v.0.10 (Sep 2014, https://github.com/appium/python-client/blob/master/README.md#appium-settings). Cheers! 🐍