### PR TITLE
Fix broken links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 install:
   - npm install
 before_script:
-  - pip install mkdocs==0.16.3
+  - pip install mkdocs
   # allow more listeners
   - echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
   - bundle install

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To locally preview appium.io
 1. Node + NPM
 1. Ruby Bundler (`gem install bundler`)
 1. pip (`brew install pip`)
-1. MkDocs 0.16.3 (`pip install mkdocs==0.16.3`)
+1. MkDocs (`pip install mkdocs`)
 
 ## Setup
 

--- a/cinder/content.html
+++ b/cinder/content.html
@@ -1,9 +1,1 @@
-{% if meta.source %}
-<div class="source-links">
-{% for filename in meta.source %}
-    <span class="label label-primary">{{ filename }}</span>
-{% endfor %}
-</div>
-{% endif %}
-
 {{ content }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,9 @@
 site_name: Appium
 docs_dir: {{language}}
-theme_dir: {{themeDir}}
+theme: 
+  name: mkdocs
+  custom_dir: {{themeDir}}
+extra:
+  base_url: {{baseUrl}}
 pages:
 {{{toc}}}

--- a/scripts/repo.js
+++ b/scripts/repo.js
@@ -128,11 +128,15 @@ async function buildDocs (pathToDocs) {
     // generate pages yaml from the sitemap
     let toc = buildDocYML(sitemap[language]);
     toc = toc.trim();
+    const baseUrl = `/docs/${language}`;
+    log.debug(`Setting base url to ${baseUrl}`);
 
-    await fs.writeFile(path.resolve(pathToDocs, 'mkdocs.yml'), mkdocsTemplate({language, themeDir, toc}));
+    await fs.writeFile(path.resolve(pathToDocs, 'mkdocs.yml'), mkdocsTemplate({language, themeDir, toc, baseUrl}));
     const pathToBuildDocsTo = path.resolve(__dirname, '..', 'docs', language);
     try {
-      await exec('mkdocs', ['build', '--site-dir', pathToBuildDocsTo], {
+      const args = ['build', '--site-dir', pathToBuildDocsTo];
+      log.debug(`Executing 'mkdocs' with args ${JSON.stringify(args)} at directory '${pathToDocs}'`);
+      await exec('mkdocs', args, {
         cwd: pathToDocs,
       });
     } catch (e) {


### PR DESCRIPTION
* Upgrade MkDocs version to 1.17 so we can add variables to templates
* Needed to add `base_url` as a variable so that absolute URL's in 404.html and some other files link to `/docs/en/path/to/asset` instead of `/path/to/asset`
* Remove meta links. Was causing an error in MkDocs 1.17

(related to: https://github.com/appium/appium/issues/11014)