### PR TITLE
docs: Remove Appium conf 2019 banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
     </div>
 </div>
 
-{% include appiumconf-banner.html %}
+<!-- {% include appiumconf-banner.html %} -->
 <nav class="navbar navbar-default" role="navigation">
     <div class="container-fluid">
         <!-- Brand and toggle get grouped for better mobile display -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,4 +4,4 @@ theme_dir: {{themeDir}}
 extra:
   base_url: {{baseUrl}}
 pages:
-{{{toc}}}
+  {{{toc}}}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,4 +4,4 @@ theme_dir: {{themeDir}}
 extra:
   base_url: {{baseUrl}}
 pages:
-  {{{toc}}}
+{{{toc}}}


### PR DESCRIPTION
The update cycle of appium.io has been backed.
Let me remove https://github.com/appium/appium.io/pull/151 as we addressed before.