### PR TITLE
Correct link to code samples at bottom of page

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
 </pre>
             <p>
                 <span data-localize="see-examples-p1">See the</span> <a
-                    href="https://github.com/appium/sample-code/tree/master/sample-code/examples"><span data-localize="see-examples-p2">Appium
+                    href="https://github.com/appium/appium/tree/master/sample-code"><span data-localize="see-examples-p2">Appium
                 example tests.</span></a>
             </p>
                 </div>


### PR DESCRIPTION
A recent edit pointed the **Examples** link in the navbar to a new location, but it looks as if the link at the bottom of the page ...

> See the [Appium example tests][bad-href].

... was overlooked. (_It currently takes you to the [boneyard][boneyard]._)

This edit updates the href at the bottom to match the href in the navbar:

> See the [Appium example tests][good-href].

[good-href]: https://github.com/appium/appium/tree/master/sample-code
[bad-href]: https://github.com/appium/sample-code/tree/master/sample-code/examples
[boneyard]: https://github.com/appium-boneyard/sample-code/tree/master/sample-code/examples