### PR TITLE
fix: specify the version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:12.22.1-alpine3.11
 WORKDIR '/root'
 RUN apk add git python2 py-pip
 COPY ./package.json ./


### PR DESCRIPTION
Fixes https://github.com/appium/appium.io/issues/302

mkdocs does not work with Python 3.7+.  https://github.com/appium/appium.io/issues/225 is an update issue for it.

This version worked on my local.